### PR TITLE
Fixed JSON and CSV resource tests

### DIFF
--- a/tests/resources/test_csvresource.py
+++ b/tests/resources/test_csvresource.py
@@ -1,4 +1,5 @@
 import os
+from os.path import realpath
 
 from dataclasses import field
 from marshmallow_dataclass import dataclass
@@ -52,7 +53,7 @@ def test_csvresource():
     assert item.y == 2
     assert item.z == 3
 
-    assert Dummy.storage_path == "data/dummies/dummies.csv"
+    assert realpath(Dummy.storage_path) == realpath("data/dummies/dummies.csv")
 
 
 def test_csvresource_parent():
@@ -70,7 +71,7 @@ def test_csvresource_parent():
     results = parent.children.find()
     assert len(results) == 3
 
-    assert parent.children.storage_path == "data/parents/00000001/children/children.csv"
+    assert realpath(parent.children.storage_path) == realpath("data/parents/00000001/children/children.csv")
 
 
 def test_csvresource_nested():

--- a/tests/resources/test_jsonresource.py
+++ b/tests/resources/test_jsonresource.py
@@ -1,4 +1,6 @@
 import os
+from os.path import realpath
+
 import time
 
 from dataclasses import field
@@ -35,7 +37,7 @@ def test_jsonresource():
     res1 = Dummy(0, "foo")
     created = res1.save()
     assert created is True
-    assert res1.get_path() == "data/dummies/00000000/dummy.json"
+    assert realpath(res1.get_path()) == realpath("data/dummies/00000000/dummy.json")
     assert os.path.exists(res1.get_path())
 
     time.sleep(1) # make sure this item has a later modified time
@@ -100,5 +102,5 @@ def test_jsonresource_subcollection():
     assert newest is not None
     assert newest.name == "child2"
 
-    assert child1.get_path() == "data/parents/00000001/children/00000001/child.json"
-    assert child2.get_path() == "data/parents/00000001/children/00000002/child.json"
+    assert realpath(child1.get_path()) == realpath("data/parents/00000001/children/00000001/child.json")
+    assert realpath(child2.get_path()) == realpath("data/parents/00000001/children/00000002/child.json")


### PR DESCRIPTION
Fixed JSON and CSV resource tests for path comparisons between Windows and Linux/Mac operating systems. The tests in tests/resources/test_jsonresource.py and tests/resources/test_csvresource.py were failing on Windows due to a simple path equality comparison based on Linux/MacOS paths.

Note: I have updated the assert tests, but the assert test in tests/resources/test_csvresource.py will still throw an error if either of those file paths do not exist in the repository. I wasn't sure whether or not that was a test needed to be added, as it was a test case checked for in the tests/resources/test_jsonresource.py file, so I did not add this test.